### PR TITLE
Improving CloudFormation resource properties

### DIFF
--- a/No6ApplicationTemplate.yml
+++ b/No6ApplicationTemplate.yml
@@ -134,7 +134,9 @@ Resources:
 
   SlackComprehensions:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
     Properties:
+      BillingMode: PAY_PER_REQUEST
       AttributeDefinitions:
         - AttributeName: channelName
           AttributeType: S
@@ -145,9 +147,6 @@ Resources:
           KeyType: HASH
         - AttributeName: comprehensionDate
           KeyType: RANGE
-      ProvisionedThroughput:
-        ReadCapacityUnits: 3
-        WriteCapacityUnits: 3
       StreamSpecification:
         StreamViewType: NEW_IMAGE
 

--- a/cmk.yml
+++ b/cmk.yml
@@ -73,6 +73,10 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 14
+            Status: Enabled
       BucketEncryption:
         ServerSideEncryptionConfiguration:
         - ServerSideEncryptionByDefault:


### PR DESCRIPTION
- Expire pipeline artifacts from S3 after 14 days
- Add a deletion policy to the DynamoDB table so it won't get recreated by accident
- Change the DynamoDB throughput to ondemand 